### PR TITLE
Rewrite deploy action to handle multi-arch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,59 +1,81 @@
 name: 'Push'
+
 on:
   push:
     branches:
       - $default-branch
   schedule:
     - cron: 2 4 10 * *
+
 jobs:
   build:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     name: 'Build'
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
-        env:
-          -
-            - jekyll:4.2.2
-            - jekyll:stable
-            - jekyll:latest
-            - jekyll:4.0
-            - jekyll:4
-          -
-            - builder:4.2.2
-            - builder:stable
-            - builder:latest
-            - builder:4.0
-            - builder:4
-          -
-            - minimal:4.2.2
-            - minimal:stable
-            - minimal:latest
-            - minimal:4.0
-            - minimal:4
-          - builder:pages
-          - minimal:pages
-          - jekyll:pages
+        variant: [jekyll, builder, minimal]
+        main_tag: [latest, pages]
+        include:
+          - main_tag: latest
+            tags: |
+              latest,priority=900
+              4.2.2,priority=700
+              4.2,priority=500
+              4,priority=300
+              stable,priority=100
+          - main_tag: pages
+            tags: pages
+
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-ruby@v1
+      - name: Checkout Code
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.x'
-      - run: bundle install
-      - run: |
-          echo $'{\n    "experimental": true\n}' | \
-            sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
-        name: 'docker experimental'
-      - name: 'docker login'
-        run: |
-          echo "${{secrets.DOCKER_PASSWORD}}" | docker login \
-            --username ${{secrets.DOCKER_USERNAME}} \
-            --password-stdin
-      - run: |
-          docker-template build $DOCKER_REPO --no-push --force --squash
-          docker-template push  $DOCKER_REPO
+          ruby-version: '2'
+          bundler-cache: true
+
+      - name: Generate Dockerfiles
         env:
           RUBYOPT: "-W0"
-          DOCKER_REPO: "${{join(matrix.env, ' ')}}"
+        run: |
+          gem install docker-template
+          docker-template cache
+
+      - name: Set Metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: jekyll/${{ matrix.variant }}
+          flavor: latest=false
+          tags: ${{ matrix.tags }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v3
+        with:
+          context: ./repos/${{ matrix.variant }}/cache/${{ matrix.main_tag }}
+          platforms: |
+            linux/386
+            linux/amd64
+            linux/arm/v6
+            linux/arm/v7
+            linux/arm64/v8
+            linux/s390x
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: "--squash"


### PR DESCRIPTION
 * Enable building images for multiple architectures within the current workflow
 * Fix deprecation of setup-ruby action
 * Fix missing tag 4.2 to follow 4.2.2